### PR TITLE
Fixed issue with missing auth token

### DIFF
--- a/client/context.js
+++ b/client/context.js
@@ -27,6 +27,7 @@ export function state() {
     products: [],
     product: null,
     cart: [],
+    authorization: null,
   };
 }
 


### PR DESCRIPTION
When using the Dashboard page, the request to retrieve the users systems was failing with a 401. This was due to the authentication variable not be defined ahead of time. This PR addresses this. 